### PR TITLE
Bump node-forge from 0.9.0 to 0.10.0 and bl from 1.2.2 to 1.2.3

### DIFF
--- a/forseti-visualizer-ui/package-lock.json
+++ b/forseti-visualizer-ui/package-lock.json
@@ -6170,7 +6170,7 @@
       }
     },
     "bl": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
@@ -15269,8 +15269,8 @@
       "dev": true
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
       "dev": true
     },
@@ -21144,7 +21144,7 @@
       "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "0.10.0"
       }
     },
     "semver": {


### PR DESCRIPTION
Security Fix: Bump node-forge from 0.9.0 to 0.10.0 and bl from 1.2.2 to 1.2.3.